### PR TITLE
Added bootstrappers for easier setup

### DIFF
--- a/demos/ComponentsDemo/Program.cs
+++ b/demos/ComponentsDemo/Program.cs
@@ -6,11 +6,10 @@ using Microsoft.Extensions.DependencyInjection;
 using Leeax.Icons.MaterialDesign;
 using Leeax.Web.Components.Modals;
 using Leeax.Web.Components.Configuration;
-using Leeax.Web.Components.DOM;
-using Leeax.Web.Components.Window;
 using Leeax.Web.Components.Cookies;
 using Leeax.Web.Components;
 using Leeax.Web.Components.Theme;
+using Leeax.Web.Components.Abstractions;
 
 namespace ComponentsDemo
 {
@@ -47,19 +46,10 @@ namespace ComponentsDemo
             // Add additional js-interop libraries
             builder.Services.AddCookies();
 
-            var host = builder.Build();
-
-            // Import all ES6 modules
-            await Task.WhenAll(
-                host.ImportDomModulesAsync(),
-                host.ImportWindowModulesAsync(),
-                host.ImportCookieModulesAsync());
-
-            // Add statis assets like CSS
-            // -> It's recommended to add the assets manually for production (in "index.html")
-            host.AddStaticAssets();
-
-            await host.RunAsync();
+            // Run bootstrappers and then the app
+            // -> Bootstrappers are required for some jsinterop libraries
+            await builder.Build()
+                .RunWithBootstrappersAsync();
         }
     }
 }

--- a/demos/ComponentsDemo/Program.cs
+++ b/demos/ComponentsDemo/Program.cs
@@ -7,9 +7,8 @@ using Leeax.Icons.MaterialDesign;
 using Leeax.Web.Components.Modals;
 using Leeax.Web.Components.Configuration;
 using Leeax.Web.Components.Cookies;
-using Leeax.Web.Components;
 using Leeax.Web.Components.Theme;
-using Leeax.Web.Components.Abstractions;
+using Leeax.Web.Components;
 
 namespace ComponentsDemo
 {

--- a/demos/ComponentsDemo/wwwroot/index.html
+++ b/demos/ComponentsDemo/wwwroot/index.html
@@ -7,6 +7,8 @@
         <base href="/" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         <link href="ComponentsDemo.styles.css" rel="stylesheet" />
+        <link href="_content/Leeax.Web.Components/bootstrap.min.css" rel="stylesheet" />
+        <link href="_content/Leeax.Web.Components/global.min.css" rel="stylesheet" />
         <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" rel="stylesheet" />
     </head>
     <body>

--- a/docs/web-components/GettingStarted.md
+++ b/docs/web-components/GettingStarted.md
@@ -60,14 +60,10 @@ public static async Task Main(string[] args)
         opt.InitialTheme = ThemeTypes.Light;
     });
     
-    var host = builder.Build();
-    
-    // Import all ES6 modules
-    await Task.WhenAll(
-        host.ImportDomModulesAsync(),
-        host.ImportWindowModulesAsync());
-    
-    await host.RunAsync();
+    // Run bootstrappers and then the app
+    // -> Bootstrappers are required for some jsinterop libraries
+    await builder.Build()
+        .RunWithBootstrappersAsync();
 }
 ```
 

--- a/docs/web-components/GettingStarted.md
+++ b/docs/web-components/GettingStarted.md
@@ -34,6 +34,8 @@ The stylesheet _"bootstrap.min.css"_ contains all required classes of bootstrap 
 ```csharp
 using Leeax.Web.Components.Configuration;
 using Leeax.Web.Components.Modals;
+using Leeax.Web.Components.Theme;
+using Leeax.Web.Components;
 
 ...
 

--- a/src/JSInterop/Leeax.Web.Components.Cookies/CookieManager.cs
+++ b/src/JSInterop/Leeax.Web.Components.Cookies/CookieManager.cs
@@ -7,6 +7,7 @@ namespace Leeax.Web.Components.Cookies
 {
     public class CookieManager : ICookieManager
     {
+        public static ModuleInfo Module = new ModuleInfo(ModulePath, ModuleKey);
         public const string ModuleKey = "__" + nameof(CookieManager);
         public const string ModulePath = "./_content/Leeax.Web.Components.Cookies/CookieManager.min.js";
 

--- a/src/JSInterop/Leeax.Web.Components.Cookies/SetupExtensions.cs
+++ b/src/JSInterop/Leeax.Web.Components.Cookies/SetupExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Leeax.Web.Components.Abstractions;
+using Leeax.Web.Components.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Linq;

--- a/src/JSInterop/Leeax.Web.Components.Cookies/SetupExtensions.cs
+++ b/src/JSInterop/Leeax.Web.Components.Cookies/SetupExtensions.cs
@@ -9,11 +9,18 @@ namespace Leeax.Web.Components.Cookies
     {
         public static void AddCookies(this IServiceCollection services)
         {
+            // Determine whether we running on WebAssembly or Server-Side
+            var jsRuntimeServiceLifetime = services
+                .First(x => x.ServiceType == typeof(IJSRuntime)).Lifetime;
+
+            // Register bootstrapper only when runnning on WebAssembly
+            if (jsRuntimeServiceLifetime == ServiceLifetime.Singleton)
+            {
+                services.AddBootstrapper(new ModuleBootstrapper(CookieManager.Module));
+            }
+
             services.AddJSObjectStore();
-            services.Add(new ServiceDescriptor(
-                typeof(ICookieManager),
-                typeof(CookieManager),
-                services.First(x => x.ServiceType == typeof(IJSRuntime)).Lifetime));
+            services.Add(new ServiceDescriptor(typeof(ICookieManager), typeof(CookieManager), jsRuntimeServiceLifetime));
         }
     }
 }

--- a/src/JSInterop/Leeax.Web.Components.DOM/ElementService.cs
+++ b/src/JSInterop/Leeax.Web.Components.DOM/ElementService.cs
@@ -9,6 +9,7 @@ namespace Leeax.Web.Components.DOM
 {
     public class ElementService : IElementService
     {
+        public static ModuleInfo Module = new ModuleInfo(ModulePath, ModuleKey);
         public const string ModuleKey = "__" + nameof(ElementService);
         public const string ModulePath = "./_content/Leeax.Web.Components.DOM/ElementService.min.js";
 

--- a/src/JSInterop/Leeax.Web.Components.DOM/HeadManager.cs
+++ b/src/JSInterop/Leeax.Web.Components.DOM/HeadManager.cs
@@ -7,6 +7,7 @@ namespace Leeax.Web.Components.DOM
 {
     public class HeadManager : IHeadManager
     {
+        public static ModuleInfo Module = new ModuleInfo(ModulePath, ModuleKey);
         public const string ModuleKey = "__" + nameof(HeadManager);
         public const string ModulePath = "./_content/Leeax.Web.Components.DOM/HeadManager.min.js";
 

--- a/src/JSInterop/Leeax.Web.Components.DOM/SetupExtensions.cs
+++ b/src/JSInterop/Leeax.Web.Components.DOM/SetupExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Leeax.Web.Components.Abstractions;
+using Leeax.Web.Components.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Linq;

--- a/src/JSInterop/Leeax.Web.Components.DOM/SetupExtensions.cs
+++ b/src/JSInterop/Leeax.Web.Components.DOM/SetupExtensions.cs
@@ -9,15 +9,19 @@ namespace Leeax.Web.Components.DOM
     {
         public static void AddDomApi(this IServiceCollection services)
         {
+            // Determine whether we running on WebAssembly or Server-Side
+            var jsRuntimeServiceLifetime = services
+                .First(x => x.ServiceType == typeof(IJSRuntime)).Lifetime;
+
+            // Register bootstrapper only when runnning on WebAssembly
+            if (jsRuntimeServiceLifetime == ServiceLifetime.Singleton)
+            {
+                services.AddBootstrapper(new ModuleBootstrapper(ElementService.Module, HeadManager.Module));
+            }
+
             services.AddJSObjectStore();
-            services.Add(new ServiceDescriptor(
-                typeof(IElementService),
-                typeof(ElementService),
-                services.First(x => x.ServiceType == typeof(IJSRuntime)).Lifetime));
-            services.Add(new ServiceDescriptor(
-                typeof(IHeadManager),
-                typeof(HeadManager),
-                services.First(x => x.ServiceType == typeof(IJSRuntime)).Lifetime));
+            services.Add(new ServiceDescriptor(typeof(IElementService), typeof(ElementService), jsRuntimeServiceLifetime));
+            services.Add(new ServiceDescriptor(typeof(IHeadManager), typeof(HeadManager), jsRuntimeServiceLifetime));
         }
     }
 }

--- a/src/JSInterop/Leeax.Web.Components.Window/SetupExtensions.cs
+++ b/src/JSInterop/Leeax.Web.Components.Window/SetupExtensions.cs
@@ -9,11 +9,18 @@ namespace Leeax.Web.Components.Window
     {
         public static void AddWindowApi(this IServiceCollection services)
         {
+            // Determine whether we running on WebAssembly or Server-Side
+            var jsRuntimeServiceLifetime = services
+                .First(x => x.ServiceType == typeof(IJSRuntime)).Lifetime;
+
+            // Register bootstrapper only when runnning on WebAssembly
+            if (jsRuntimeServiceLifetime == ServiceLifetime.Singleton)
+            {
+                services.AddBootstrapper(new ModuleBootstrapper(WindowService.Module));
+            }
+
             services.AddJSObjectStore();
-            services.Add(new ServiceDescriptor(
-                typeof(IWindowService),
-                typeof(WindowService),
-                services.First(x => x.ServiceType == typeof(IJSRuntime)).Lifetime));
+            services.Add(new ServiceDescriptor(typeof(IWindowService), typeof(WindowService), jsRuntimeServiceLifetime));
         }
     }
 }

--- a/src/JSInterop/Leeax.Web.Components.Window/SetupExtensions.cs
+++ b/src/JSInterop/Leeax.Web.Components.Window/SetupExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Leeax.Web.Components.Abstractions;
+using Leeax.Web.Components.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System.Linq;

--- a/src/JSInterop/Leeax.Web.Components.Window/WindowService.cs
+++ b/src/JSInterop/Leeax.Web.Components.Window/WindowService.cs
@@ -7,8 +7,9 @@ namespace Leeax.Web.Components.Window
 {
     public class WindowService : IWindowService
     {
-        internal const string ModuleKey = "__" + nameof(WindowService);
-        internal const string ModulePath = "./_content/Leeax.Web.Components.Window/WindowService.min.js";
+        public static ModuleInfo Module = new ModuleInfo(ModulePath, ModuleKey);
+        public const string ModuleKey = "__" + nameof(WindowService);
+        public const string ModulePath = "./_content/Leeax.Web.Components.Window/WindowService.min.js";
 
         private readonly IJSInProcessObjectReference? _jsInProcessObjectRef;
         private readonly IJSRuntime _jsRuntime;

--- a/src/Leeax.Web.Components.Abstractions/BootstrapperUtilities.cs
+++ b/src/Leeax.Web.Components.Abstractions/BootstrapperUtilities.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Threading.Tasks;
+
+namespace Leeax.Web.Components.Abstractions
+{
+    public static class BootstrapperUtilities
+    {
+        public static async Task RunFromServiceProviderAsync(IServiceProvider serviceProvider)
+        {
+            var bootstrappers = serviceProvider.GetServices<IBootstrapper>();
+
+            foreach (var curBootstrapper in bootstrappers)
+            {
+                // Skip invalid bootstrapper
+                if (curBootstrapper == null)
+                {
+                    continue;
+                }
+
+                var name = curBootstrapper.Name ?? "Unnamed";
+
+                try
+                {
+                    // Run the bootstrapper and wait for the exit code
+                    var exitCode = await curBootstrapper.RunAsync(serviceProvider);
+
+                    // Everything other than zero is a possible failure
+                    // -> Log some info into console (we may want to integrate an actual logger at some point)
+                    if (exitCode != 0)
+                    {
+                        Console.WriteLine($"[{curBootstrapper.GetType().FullName}] Bootstrapper \"{name}\" exited with code \"{exitCode}\".");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    // Log the exception into the console
+                    Console.WriteLine($"[{curBootstrapper.GetType().FullName}] Bootstrapper \"{name}\" exited unexpected with code \"1\": " + ex.Message);
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/Leeax.Web.Components.Abstractions/IBootstrapper.cs
+++ b/src/Leeax.Web.Components.Abstractions/IBootstrapper.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Leeax.Web.Components.Abstractions
+{
+    public interface IBootstrapper
+    {
+        /// <summary>
+        /// Runs the bootstrapper and returns an exit code.
+        /// Everything other than zero is considered as a failure.
+        /// </summary>
+        public Task<int> RunAsync(IServiceProvider serviceProvider);
+
+        /// <summary>
+        /// Gets the concrete name of the bootstrapper.
+        /// </summary>
+        string Name { get; }
+    }
+}

--- a/src/Leeax.Web.Components.Abstractions/JSRuntimeExtensions.cs
+++ b/src/Leeax.Web.Components.Abstractions/JSRuntimeExtensions.cs
@@ -6,10 +6,10 @@ namespace Leeax.Web.Components.Abstractions
 {
     public static class JSRuntimeExtensions
     {
-        public static Task<IJSObjectReference> ImportModuleAsync(this IJSRuntime jsRuntime, string path, string? name, IJSObjectReferenceStore? store = null)
+        public static Task<IJSObjectReference> ImportModuleAsync(this IJSRuntime jsRuntime, string path, string? name = null, IJSObjectReferenceStore? store = null)
             => ImportModuleAsync<IJSObjectReference>(jsRuntime, path, name, store);
 
-        public static async Task<T> ImportModuleAsync<T>(this IJSRuntime jsRuntime, string path, string? name, IJSObjectReferenceStore? store = null) 
+        public static async Task<T> ImportModuleAsync<T>(this IJSRuntime jsRuntime, string path, string? name = null, IJSObjectReferenceStore? store = null) 
             where T : IJSObjectReference
         {
             _ = path ?? throw new ArgumentNullException(nameof(path));

--- a/src/Leeax.Web.Components.Abstractions/Leeax.Web.Components.Abstractions.csproj
+++ b/src/Leeax.Web.Components.Abstractions/Leeax.Web.Components.Abstractions.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.JSInterop" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Leeax.Web.Components.Abstractions/ModuleBootstrapper.cs
+++ b/src/Leeax.Web.Components.Abstractions/ModuleBootstrapper.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Leeax.Web.Components.Abstractions
+{
+    /// <summary>
+    /// Imports a javascript ES6 module and stores it in the registered <see cref="IJSObjectReferenceStore"/>.
+    /// </summary>
+    public class ModuleBootstrapper : IBootstrapper
+    {
+        private readonly IEnumerable<ModuleInfo> _modules;
+
+        public ModuleBootstrapper(ModuleInfo module)
+        {
+            _modules = new ModuleInfo[] { module };
+        }
+
+        public ModuleBootstrapper(IEnumerable<ModuleInfo> modules)
+        {
+            _modules = modules ?? throw new ArgumentNullException(nameof(modules));
+        }
+
+        public async Task<int> RunAsync(IServiceProvider serviceProvider)
+        {
+            var jsRuntime = serviceProvider.GetRequiredService<IJSRuntime>();
+            var store = serviceProvider.GetRequiredService<IJSObjectReferenceStore>();
+
+            foreach (var curModule in _modules)
+            {
+                if (jsRuntime is IJSInProcessRuntime)
+                {
+                    await jsRuntime.ImportModuleAsync<IJSInProcessObjectReference>(
+                        curModule.Path,
+                        curModule.Name,
+                        store);
+                }
+                else
+                {
+                    await jsRuntime.ImportModuleAsync(
+                        curModule.Path,
+                        curModule.Name,
+                        store);
+                }
+            }
+
+            return 0;
+        }
+
+        public string Name => "ES6 module bootstrapper";
+    }
+}

--- a/src/Leeax.Web.Components.Abstractions/ModuleBootstrapper.cs
+++ b/src/Leeax.Web.Components.Abstractions/ModuleBootstrapper.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Leeax.Web.Components.Abstractions
@@ -11,14 +10,9 @@ namespace Leeax.Web.Components.Abstractions
     /// </summary>
     public class ModuleBootstrapper : IBootstrapper
     {
-        private readonly IEnumerable<ModuleInfo> _modules;
+        private readonly ModuleInfo[] _modules;
 
-        public ModuleBootstrapper(ModuleInfo module)
-        {
-            _modules = new ModuleInfo[] { module };
-        }
-
-        public ModuleBootstrapper(IEnumerable<ModuleInfo> modules)
+        public ModuleBootstrapper(params ModuleInfo[] modules)
         {
             _modules = modules ?? throw new ArgumentNullException(nameof(modules));
         }

--- a/src/Leeax.Web.Components.Abstractions/ModuleInfo.cs
+++ b/src/Leeax.Web.Components.Abstractions/ModuleInfo.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Leeax.Web.Components.Abstractions
+{
+    public readonly struct ModuleInfo
+    {
+        public ModuleInfo(string path)
+            : this(path, null)
+        {
+        }
+
+        public ModuleInfo(string path, string? name)
+        {
+            Path = path ?? throw new ArgumentNullException(nameof(path));
+            Name = name ?? path;
+        }
+
+        public string Path { get; }
+
+        public string Name { get; }
+    }
+}

--- a/src/Leeax.Web.Components.Abstractions/SetupExtensions.cs
+++ b/src/Leeax.Web.Components.Abstractions/SetupExtensions.cs
@@ -1,13 +1,25 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
 
 namespace Leeax.Web.Components.Abstractions
 {
     public static class SetupExtensions
     {
-        public static void AddJSObjectStore(this IServiceCollection services)
+        public static IServiceCollection AddJSObjectStore(this IServiceCollection services)
         {
             services.TryAddSingleton<IJSObjectReferenceStore, JSObjectReferenceStore>();
+
+            return services;
+        }
+
+        public static IServiceCollection AddBootstrapper(this IServiceCollection services, IBootstrapper bootstrapper)
+        {
+            _ = bootstrapper ?? throw new ArgumentNullException(nameof(bootstrapper));
+
+            services.AddSingleton<IBootstrapper>(bootstrapper);
+
+            return services;
         }
     }
 }

--- a/src/Leeax.Web.Components.Abstractions/SetupExtensions.cs
+++ b/src/Leeax.Web.Components.Abstractions/SetupExtensions.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Leeax.Web.Components.Abstractions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 
-namespace Leeax.Web.Components.Abstractions
+namespace Leeax.Web.Components.Configuration
 {
     public static class SetupExtensions
     {

--- a/src/Leeax.Web.Components.Abstractions/WebAssemblyHostExtensions.cs
+++ b/src/Leeax.Web.Components.Abstractions/WebAssemblyHostExtensions.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+﻿using Leeax.Web.Components.Abstractions;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using System.Threading.Tasks;
 
-namespace Leeax.Web.Components.Abstractions
+namespace Leeax.Web.Components.Configuration
 {
     public static class WebAssemblyHostExtensions
     {

--- a/src/Leeax.Web.Components.Abstractions/WebAssemblyHostExtensions.cs
+++ b/src/Leeax.Web.Components.Abstractions/WebAssemblyHostExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using System.Threading.Tasks;
+
+namespace Leeax.Web.Components.Abstractions
+{
+    public static class WebAssemblyHostExtensions
+    {
+        public static Task RunWithBootstrappersAsync(this WebAssemblyHost host)
+        {
+            return BootstrapperUtilities
+                .RunFromServiceProviderAsync(host.Services)
+                .ContinueWith(x => host.RunAsync());
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces the possibility to register bootstrappers which are inheriting from the `IBootstrapper` interface. By default, these are executed before the actual app starts and can do some asynchronous work.
> **Note**: Bootstrappers are preventing the app from starting until fully executed, so don't wait for long running tasks

Bootstrappers are registered like normal services:
```cs
// Program.cs
...
builder.Services.AddBootstrapper(new CustomBootstrapper());
```

To ensure that all registered bootstrappers are actually executed, the app needs to be started like so:
```cs 
// Start the application with bootstrappers
await builder.Build()
    .RunWithBootstrappersAsync();
```

If required, the application could be started normally and the registered bootstrappers could be executed manually later on:
```cs
// Runs all bootstrappers from the supplied "IServiceProvider"
// -> Use only when you know what you're doing
BootstrapperUtilities.RunFromServiceProviderAsync(serviceProvider)
```