### PR TITLE
Fixed weird behavior with the checkbox components

### DIFF
--- a/src/Leeax.Web.Components/Input/Checkbox/LxCheckbox.razor
+++ b/src/Leeax.Web.Components/Input/Checkbox/LxCheckbox.razor
@@ -2,5 +2,7 @@
 @inherits ValueComponentBase<bool>
 
 <label @attributes="AttributeSet">
-    <input type="checkbox" value="@Value" @onchange="OnValueChanged" />
+    <input type="checkbox"
+           checked="@Value"
+           @onchange="OnValueChanged" />
 </label>

--- a/src/Leeax.Web.Components/Input/Toggle/LxToggle.razor
+++ b/src/Leeax.Web.Components/Input/Toggle/LxToggle.razor
@@ -3,6 +3,6 @@
 
 <label @attributes="AttributeSet">
     <input type="checkbox"
-           value="@Value"
+           checked="@Value"
            @onchange="OnValueChanged" />
 </label>


### PR DESCRIPTION
Added `checked` attribute to input elements. Previously the `value` attribute was used which didn't set the correct value.

Closes #10 